### PR TITLE
Make the default policy 1w:5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Follows a specified schedule passed as a commandline argument and purges old rot
 ./rotate -help
 Usage of ./rotate:
   -format="2006-01-02": date format used in filenames as a representation of January 2, 2006
-  -schedule="1d:7,1w:4,1m:12,1y:4": rotation schedule and retention period
+  -schedule="1d:7,1w:5,1m:12,1y:4": rotation schedule and retention period
   -verbose=false: verbose output
   -version=false: prints current version
 ```

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ var config struct {
 
 func init() {
 	flag.StringVar(&config.format, "format", "2006-01-02", "date format used in filenames as a representation of January 2, 2006")
-	flag.StringVar(&config.schedule, "schedule", "1d:7,1w:4,1m:12,1y:4", "rotation schedule and retention period")
+	flag.StringVar(&config.schedule, "schedule", "1d:7,1w:5,1m:12,1y:4", "rotation schedule and retention period")
 	flag.BoolVar(&config.version, "version", false, "prints current version")
 	flag.BoolVar(&config.verbose, "verbose", false, "verbose output")
 }


### PR DESCRIPTION
There are >4 weeks in the majority of months. For that reason, some other tools (e.g. [AutoMySQLBackup](http://www.debianhelp.co.uk/mysqlscript.htm), [AutoPostgresqlBackup](https://launchpad.net/ubuntu/+source/autopostgresqlbackup/1.0-1)) seem to default to 5 weekly backups.

I think the worst possible scenario is as follows - Your monthly rotation happens on the 1st of the month. It's now the 31st of the month. You have the default strategy. On a calendar that looks something like this:

```
30      6       13      20      27 d
31      7       14      21      28 d
1  m    8       15      22      29 d
2       9       16      23      30 d
3       10 w    17 w    24 w    31 dw <- today
4       11      18      25 d
5       12      19      26 d
```

It's now the 31st of the month and you might expect that there is no more than 7 days between your files (as you have weekly rotation) for the past month. However note that there is a 9 day period between monthly rotated file taken on the 1st of the month and your last weekly rotation which happens to be on the 3,10,17,24,31 days of this month - but the rotation on the 3rd has been aged out.

For this reason, I suggest making the default `1w:5`
